### PR TITLE
Simplify docker and update Rust to 1.82

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trust_ip"
-version = "2.0.1"
+version = "2.0.2"
 edition = "2021"
 
 [dependencies]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,18 @@
-FROM alpine:3.19.1 as builder
+FROM rust:1.82-alpine AS builder
 
 WORKDIR /build
 
-RUN apk add gcc musl-dev libffi-dev curl openssl-dev openssl openssl-libs-static && \
-    curl –proto ‘=https’ –tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -q -y && \
-    mkdir -p /build/src
+RUN apk add musl-dev
 
-COPY src/main.rs ./src
+COPY src ./src
 COPY Cargo.toml .
 
-RUN source $HOME/.cargo/env && \
-    arch=$(arch) && \
+RUN arch=$(arch) && \
     cargo build --release --target $arch-unknown-linux-musl && \
-    mv /build/target/$arch-unknown-linux-musl/release/trust_ip /build/target
+    mv /build/target/$arch-unknown-linux-musl/release/trust_ip /
 
 FROM scratch
 
-COPY --from=builder /build/target/trust_ip .
+COPY --from=builder /trust_ip .
 
 CMD ["/trust_ip"]


### PR DESCRIPTION
- Simplified dockerfile to use the Alpine Rust image instead of building our own
- Updated Rust version to 1.82